### PR TITLE
Finance and Notes text boxes

### DIFF
--- a/mgt2e/css/mgt2.css
+++ b/mgt2e/css/mgt2.css
@@ -1247,13 +1247,6 @@ textarea.traits {
   background-color: #F0F0F0;
 }
 
-.notes-description .editor {
-  padding: 5px;
-  min-height: 200px;
-  height: 100%;
-  background-color: #F0F0F0;
-}
-
 .item-description .editor {
   padding: 5px;
   min-height: 200px;
@@ -1509,15 +1502,6 @@ h1.charname input {
   min-height: 100px;
 }
 
-.notes-description {
-  min-height: 200px;
-  border: 2px groove #f0f0f0;
-}
-
-.notes-description editor {
-  height: 100%;
-  min-height: 100px;
-}
 .character-right div.npc-info {
   display: flex;
   flex: 0 0 auto;

--- a/mgt2e/lang/en.json
+++ b/mgt2e/lang/en.json
@@ -265,7 +265,6 @@
   "MGT2.TravellerSheet.History": "History",
   "MGT2.TravellerSheet.Settings": "Settings",
   "MGT2.TravellerSheet.HomeWorld": "Homeworld",
-  "MGT2.TravellerSheet.Notes": "Notes",
 
   "MGT2.TravellerSheet.Terms": "Terms",
   "MGT2.TravellerSheet.Height": "Height (cm)",

--- a/mgt2e/module/sheets/actor-sheet.mjs
+++ b/mgt2e/module/sheets/actor-sheet.mjs
@@ -66,10 +66,6 @@ export class MgT2ActorSheet extends foundry.appv1.sheets.ActorSheet {
             actorData.finance.description,
             { secrets: ((context.actor.permission > 2)?true:false) }
         );
-        context.enrichedNotes = await foundry.applications.ux.TextEditor.enrichHTML(
-            actorData.notes,
-            { secrets: ((context.actor.permission > 2)?true:false) }
-        );
         context.flags = actorData.flags;
         context.currentYear = game.settings.get("mgt2e", "currentYear");
 

--- a/mgt2e/template.json
+++ b/mgt2e/template.json
@@ -137,8 +137,7 @@
       "startAge": 18,
       "termLength": 4,
       "entryYear": 1105,
-      "entryAge": 18,
-      "notes": ""
+      "entryAge": 18
     },
     "npc": {
         "templates": [ "base", "characteristics", "skills", "armour", "sophont" ],

--- a/mgt2e/templates/actor/actor-traveller-sheet.html
+++ b/mgt2e/templates/actor/actor-traveller-sheet.html
@@ -130,9 +130,6 @@
                     {{#if (isObserver .)}}
                         <a class="item" data-tab="history">{{localize 'MGT2.TravellerSheet.History'}}</a>
                     {{/if}}
-                    {{#if (isObserver .)}}
-                        <a class="item" data-tab="notes">{{localize 'MGT2.TravellerSheet.Notes'}}</a>
-                    {{/if}}
                     {{#if (isOwner .)}}
                         <a class="item" data-tab="settings">{{localize 'MGT2.TravellerSheet.Settings'}}</a>
                     {{/if}}
@@ -218,17 +215,6 @@
                     <div class="tab history" data-group="primary" data-tab="history">
                         <section>
                             {{> "systems/mgt2e/templates/actor/parts/actor-terms.html"}}
-                        </section>
-                    </div>
-                    {{/if}}
-
-                    {{#if (isObserver .)}}
-                    {{!-- Notes Tab --}}
-                    <div class="tab notes" data-group="primary" data-tab="notes">
-                        <section class="notes-description">
-                            {{editor
-                                enrichedNotes target="system.notes"
-                                button=true editable=editable}}
                         </section>
                     </div>
                     {{/if}}


### PR DESCRIPTION
Added a 'financial notes' text box under the finance tab and a new 'notes' tab. This was made to help compartmentalize descriptions and notes based on priority. The idea is that the description field should be the most static, only holding backstory and description information. While the Financial Notes holds occasionally updated information such as debt payments, special memberships (such as TAS), patron rewards etc... While the notes tab is the most frequently updated with session notes or quick reminders.