### PR TITLE
Psionic Powers

### DIFF
--- a/mgt2e/lang/en.json
+++ b/mgt2e/lang/en.json
@@ -106,6 +106,16 @@
   "MGT2.TaskDifficulty.15": "Formidable",
   "MGT2.TaskDifficulty.16": "Impossible",
 
+  "MGT2.TaskTime.1": "1D Seconds",
+  "MGT2.TaskTime.2": "1D Rounds",
+  "MGT2.TaskTime.3": "1D x 10 Seconds",
+  "MGT2.TaskTime.4": "1D Minutes",
+  "MGT2.TaskTime.5": "1D x 10 Minutes",
+  "MGT2.TaskTime.6": "1D Hours",
+  "MGT2.TaskTime.7": "1D x 4 Hours",
+  "MGT2.TaskTime.8": "1D x 10 Hours",
+  "MGT2.TaskTime.9": "1D Days",
+
   "MGT2.TaskEffect.ExceptionalFailure": "Exceptional Failure",
   "MGT2.TaskEffect.AverageFailure": "Average Failure",
   "MGT2.TaskEffect.MarginalFailure": "Marginal Failure",
@@ -260,6 +270,7 @@
   "MGT2.TravellerSheet.Hits": "HITS",
   "MGT2.TravellerSheet.Rads": "RADS",
   "MGT2.TravellerSheet.Dodge": "DODGE",
+  "MGT2.TravellerSheet.Powers": "Powers",
 
   "MGT2.TravellerSheet.Skills": "Skills",
   "MGT2.TravellerSheet.Equipment": "Equipment",
@@ -1289,6 +1300,18 @@
   "MGT2.Item.SpaceMount.Spinal": "Spinal Mount",
   "MGT2.Item.Power": "Power",
 
+  "MGT2.Item.Psionic.Range": "Range",
+  "MGT2.Item.PsionicRange.1": "Personal (<1m)",
+  "MGT2.Item.PsionicRange.2": "Close (1m+)",
+  "MGT2.Item.PsionicRange.3": "Short (6m+)",
+  "MGT2.Item.PsionicRange.4": "Medium (11m+)",
+  "MGT2.Item.PsionicRange.5": "Long (51m+)",
+  "MGT2.Item.PsionicRange.6": "Very Long (251m+)",
+  "MGT2.Item.PsionicRange.7": "Distant (501m+)",
+  "MGT2.Item.PsionicRange.8": "Very Distant (6km+)",
+  "MGT2.Item.PsionicRange.9": "Continental (501km+)",
+  "MGT2.Item.PsionicRange.10": "Planetary (5,001-50,000km)",
+
   "MGT2.Item.Hardware.Rating.j-drive": "Jump-{rating}",
   "MGT2.Item.Hardware.Rating.m-drive": "{rating} G",
   "MGT2.Item.Hardware.Rating.r-drive": "{rating} G",
@@ -1352,6 +1375,12 @@
   "MGT2.Armour.Psi": "Psi",
   "MGT2.Armour.VaccSuit": "Vacc Suit {skill}",
 
+  "MGT2.Psi.Talent": "Talent",
+  "MGT2.Psi.Cost": "Psi-point Cost",
+  "MGT2.Psi.Reach": "Reach",
+  "MGT2.Psi.Check": "Check",
+  "MGT2.Psi.Time": "Timeframe",
+  
   "MGT2.Effects.Disabled": "Disabled",
   "MGT2.Effects.Origin": "Origin",
   "MGT2.Effects.Transfer": "Transfer",
@@ -1490,6 +1519,8 @@
   "MGT2.Info.BuyItem": "{actor} spends Cr{cost} on buying {item}",
   "MGT2.Warn.NoActorsToBuy": "No actors available who can buy this item",
   "MGT2.Warn.ThisActorCannotBuy": "{actor} doesn't have enough cash to buy {item}",
+
+  "MGT2.Warn.NoPsi": "{actor} has no Psi points",
 
   "MGT2.Error.NoStatus": "Unable to find status '{status}'",
 
@@ -1631,6 +1662,7 @@
   "TYPES.Item.associate": "Background Associate",
   "TYPES.Item.role": "Crew Role",
   "TYPES.Item.software": "Software",
+  "TYPES.Item.power": "Power",
   "TYPES.Item.worlddata": "World Data",
 
   "EFFECT.Injured": "Injured",

--- a/mgt2e/module/documents/item.mjs
+++ b/mgt2e/module/documents/item.mjs
@@ -170,7 +170,7 @@ export class MgT2Item extends Item {
             if (!this.actor.system.damage["PSI"]) {
             this.actor.system.damage["PSI"] = { "value": 0 };
             };
-            if (this.actor.system.characteristics["PSI"].value <= this.actor.system.damage["PSI"].value){
+            if (this.actor.system.characteristics["PSI"].current <= 0){
                 ui.notifications.warn(game.i18n.format("MGT2.Warn.NoPsi",
                     { "actor": this.actor.name }));
                 return;

--- a/mgt2e/module/documents/item.mjs
+++ b/mgt2e/module/documents/item.mjs
@@ -1,5 +1,6 @@
 
 import {MgT2AttackDialog } from "../helpers/attack-dialog.mjs";
+import {MgT2PowerDialog } from "../helpers/power-dialog.mjs";
 import {rollAttack} from "../helpers/dice-rolls.mjs";
 import {getSkillValue} from "../helpers/dice-rolls.mjs";
 
@@ -163,6 +164,19 @@ export class MgT2Item extends Item {
                 } else {
                     // No Ammo.
                 }
+            }
+        }
+        if (item.type === "power" && this.actor.system.characteristics) {
+            if (!this.actor.system.damage["PSI"]) {
+            this.actor.system.damage["PSI"] = { "value": 0 };
+            };
+            if (this.actor.system.characteristics["PSI"].value <= this.actor.system.damage["PSI"].value){
+                ui.notifications.warn(game.i18n.format("MGT2.Warn.NoPsi",
+                    { "actor": this.actor.name }));
+                return;
+            }
+            if (!quickRoll) {
+                new MgT2PowerDialog(this.actor, item).render(true);
             }
         }
     }

--- a/mgt2e/module/helpers/power-dialog.mjs
+++ b/mgt2e/module/helpers/power-dialog.mjs
@@ -1,0 +1,108 @@
+import { skillLabel, getSkillValue, rollSkill } from "../helpers/dice-rolls.mjs";
+
+// Allow damage characteristics to be modified.
+export class MgT2PowerDialog extends Application {
+    static get defaultOptions() {
+        const options = super.defaultOptions;
+        options.template = "systems/mgt2e/templates/power-dialog.html";
+        options.width = "400";
+        options.height = "auto";
+        options.title = "Use Power";
+        return options;
+    }
+
+    constructor(actor, power) {
+        super();
+        this.actor = actor;
+        this.power = power;
+
+        const data = actor.system;
+        this.data = data;
+        this.skill = this.power.system.power.skill.split(".")[0];
+        this.speciality = this.power.system.power.skill.split(".")[1];
+        this.score = parseInt(getSkillValue(this.actor, this.skill, this.speciality));
+        this.range = parseInt(this.power.system.power.range);
+        this.cost = parseInt(this.power.system.power.cost);
+        this.check = parseInt(this.power.system.power.check);
+
+        this.RANGES = {};
+        //Adds the current range and up to two range bands further
+        for (let t = 0; t <= 2 && (this.range + t) <= 10; t += 1) {
+            this.RANGES[t + this.range] = `${game.i18n.localize("MGT2.Item.PsionicRange." + (this.range + t))} Psi: ${this.cost * (2 ** (t))}`;
+        };
+        this.ROLLTYPES = {
+            "normal": game.i18n.localize("MGT2.TravellerSheet.Normal"),
+            "boon": game.i18n.localize("MGT2.TravellerSheet.Boon"),
+            "bane": game.i18n.localize("MGT2.TravellerSheet.Bane")
+        };
+
+        this.MODE_SELECT = {
+            "publicroll": game.i18n.localize("MGT2.Dialog.Public"),
+            "gmroll": game.i18n.localize("MGT2.Dialog.Private"),
+            "blindroll": game.i18n.localize("MGT2.Dialog.Blind"),
+            "selfroll": game.i18n.localize("MGT2.Dialog.Self")
+        }
+
+        let mode = game.settings.get("core", "rollMode")
+
+    }
+
+    getData() {
+        return {
+            "power": this.power,
+            "score": this.score,
+            "cha": "PSI",
+            "skill": skillLabel(this.data.skills[this.skill]),
+            "speciality": (this.skill && this.speciality) ? skillLabel(this.data.skills[this.skill].specialities[this.speciality]) : "",
+            "dicetype": "normal",
+            "RANGES": this.RANGES,
+            "ROLLTYPES": this.ROLLTYPES,
+            "MODE_SELECT": this.MODE_SELECT,
+            "mode": this.mode
+        }
+    }
+
+    activateListeners(html) {
+        super.activateListeners(html);
+        const roll = html.find("button[class='roll']");
+        roll.on("click", event => this.onRollClick(event, html));
+    }
+
+    async onRollClick(event, html) {
+        event.preventDefault();
+
+        let dm = parseInt(html.find("input[class='skillDialogDM']")[0].value);
+        let rollType = html.find(".skillDialogRollType")[0].value;
+        let rollMode = html.find(".skillDialogRollMode")[0].value;
+        let range = parseInt(html.find(".skillDialogRange")[0].value);
+        let psiPoints = this.cost * (2 ** (range - this.range));
+
+        let powerOptions = {
+            "skillDM": this.score,
+            "dm": dm,
+            "rollType": rollType,
+            "difficulty": this.check,
+            "rollMode": rollMode
+        };
+
+        const total = await rollSkill(this.actor, this.skill, powerOptions);
+        if (total < this.check) {
+            psiPoints = 1;
+        };
+        if (!this.actor.system.damage["PSI"]) {
+            this.actor.system.damage["PSI"] = { "value": 0 };
+        };
+
+        let overflow = psiPoints - (this.actor.system.characteristics["PSI"].value - this.actor.system.damage["PSI"].value);
+        this.actor.system.damage["PSI"].value += psiPoints;
+        this.actor.update({ "system.damage": this.actor.system.damage });
+        if (overflow > 0) {
+            this.actor.applyActualDamageToTraveller(overflow, {});
+        };
+
+        this.close();
+    }
+
+}
+
+window.MgT2PowerDialog = MgT2PowerDialog;

--- a/mgt2e/module/helpers/power-dialog.mjs
+++ b/mgt2e/module/helpers/power-dialog.mjs
@@ -43,7 +43,7 @@ export class MgT2PowerDialog extends Application {
             "selfroll": game.i18n.localize("MGT2.Dialog.Self")
         }
 
-        let mode = game.settings.get("core", "rollMode")
+        this.mode = game.settings.get("core", "rollMode")
 
     }
 

--- a/mgt2e/module/helpers/power-dialog.mjs
+++ b/mgt2e/module/helpers/power-dialog.mjs
@@ -54,6 +54,7 @@ export class MgT2PowerDialog extends Application {
             "cha": "PSI",
             "skill": skillLabel(this.data.skills[this.skill]),
             "speciality": (this.skill && this.speciality) ? skillLabel(this.data.skills[this.skill].specialities[this.speciality]) : "",
+            "dm": 0,
             "dicetype": "normal",
             "RANGES": this.RANGES,
             "ROLLTYPES": this.ROLLTYPES,

--- a/mgt2e/module/helpers/templates.mjs
+++ b/mgt2e/module/helpers/templates.mjs
@@ -7,6 +7,7 @@ export const preloadHandlebarsTemplates = async function() {
     return loadTemplates([
         // Actor partials.
         "systems/mgt2e/templates/actor/parts/actor-items.html",
+        "systems/mgt2e/templates/actor/parts/actor-powers.html",
         "systems/mgt2e/templates/actor/parts/actor-combat.html",
         "systems/mgt2e/templates/actor/parts/actor-status.html",
         "systems/mgt2e/templates/actor/parts/actor-effects.html",

--- a/mgt2e/module/mgt2.mjs
+++ b/mgt2e/module/mgt2.mjs
@@ -1224,7 +1224,7 @@ Handlebars.registerHelper('isItemOwned', function(item) {
     if (item.system.status === MgT2Item.EQUIPPED || item.system.status === MgT2Item.CARRIED) {
         return false;
     }
-    if (item.type === "term" || item.type === "associate") {
+    if (item.type === "term" || item.type === "associate" || item.type === "power") {
         return false;
     }
     return true;

--- a/mgt2e/module/sheets/actor-sheet.mjs
+++ b/mgt2e/module/sheets/actor-sheet.mjs
@@ -629,6 +629,7 @@ export class MgT2ActorSheet extends foundry.appv1.sheets.ActorSheet {
         const armour = [];
         const terms = [];
         const associates = [];
+        const powers = [];
 
         let weight = 0;
         let skillNeeded = -3;
@@ -668,6 +669,8 @@ export class MgT2ActorSheet extends foundry.appv1.sheets.ActorSheet {
                 armour.push(i);
             } else if (i.type === 'term') {
                 terms.push(i);
+            } else if (i.type === 'power') {
+                powers.push(i);
             } else if (i.type === "associate") {
                 associates.push(i);
             } else {
@@ -720,6 +723,7 @@ export class MgT2ActorSheet extends foundry.appv1.sheets.ActorSheet {
         context.activeWeapons = activeWeapons;
         context.armour = armour;
         context.terms = terms;
+        context.powers = powers;
         context.associates = associates;
 
         context.GEAR = context.gear;
@@ -2677,7 +2681,6 @@ export class MgT2ActorSheet extends foundry.appv1.sheets.ActorSheet {
         event.preventDefault();
         const element = event.currentTarget;
         const dataset = element.dataset;
-
         // Handle item rolls.
         if (dataset.rollType) {
             if (dataset.rollType === 'item') {

--- a/mgt2e/module/sheets/item-sheet.mjs
+++ b/mgt2e/module/sheets/item-sheet.mjs
@@ -450,7 +450,67 @@ export class MgT2ItemSheet extends foundry.appv1.sheets.ItemSheet {
                 return 1;
             });
             context.combatSkills = Object.fromEntries(sorted);
-        } else if (item.type === "cargo") {
+        } 
+        else if (item.type === "power"){
+            let reach = {};
+            for (let t=1; t <= 10; t += 1) {
+                reach[t] = game.i18n.localize("MGT2.Item.PsionicRange." + t);
+            }
+            context.psionicRange = reach;
+            // context.psionicReach = {
+            //     "personal": game.i18n.localize("MGT2.Item.Psionic.personal"),
+            //     "close": game.i18n.localize("MGT2.Item.Psionic.close"),
+            //     "short": game.i18n.localize("MGT2.Item.Psionic.short"),
+            //     "medium": game.i18n.localize("MGT2.Item.Psionic.medium"),
+            //     "long": game.i18n.localize("MGT2.Item.Psionic.long"),
+            //     "verylong": game.i18n.localize("MGT2.Item.Psionic.verylong"),
+            //     "distant": game.i18n.localize("MGT2.Item.Psionic.distant"),
+            //     "verydistant": game.i18n.localize("MGT2.Item.Psionic.verydistant"),
+            //     "continental": game.i18n.localize("MGT2.Item.Psionic.continental"),
+            //     "planetary": game.i18n.localize("MGT2.Item.Psionic.planetary")
+            // };
+            let difficultySelect = {};
+            for (let t=2; t <= 16; t += 2) {
+                difficultySelect[t] = game.i18n.localize("MGT2.TaskDifficulty." + t) + ` (${t}+)`;
+            }
+            context.difficulty = difficultySelect;
+
+            let timeSelect = {};
+            for (let t=1; t <= 9; t += 1) {
+                timeSelect[t] = game.i18n.localize("MGT2.TaskTime." + t);
+            }
+            context.timeFrame = timeSelect;
+
+            let allSkills = MGT2.getDefaultSkills();
+            context.psiSkills = {
+                "": "None"
+            };
+            for (let skillId in allSkills) {
+                let skill = allSkills[skillId];
+                if (skill.specialities) {
+                    for (let specId in skill.specialities) {
+                        let spec = skill.specialities[specId];
+                        if (skill.trait === "psionic") {
+                            let label = skill.label?skill.label:game.i18n.localize("MGT2.Skills."+skillId);
+                            let specLabel = spec.label?spec.label:game.i18n.localize("MGT2.Skills."+specId);
+                            context.psiSkills[skillId+"."+specId] = label + " (" + specLabel + ")";
+                        }
+                    }
+                } else if (skill.trait === "psionic") {
+                    context.psiSkills[skillId] = skill.label?skill.label:game.i18n.localize("MGT2.Skills."+skillId);
+                }
+            }
+            let sorted = Object.entries(context.psiSkills).sort((a,b) => {
+                if (a[0] === "") return -1;
+                if (b[0] === "") return 1;
+                if (a[1] < b[1]) {
+                    return -1;
+                }
+                return 1;
+            });
+            context.psiSkills = Object.fromEntries(sorted);
+        }
+            else if (item.type === "cargo") {
             context.availability = {};
             context.haveAvailability = {};
             context.purchaseTraits = {};

--- a/mgt2e/template.json
+++ b/mgt2e/template.json
@@ -307,7 +307,7 @@
     }
   },
   "Item": {
-    "types": ["item", "weapon", "armour", "augment", "term", "associate", "cargo", "hardware", "role", "software", "worlddata" ],
+    "types": ["item", "weapon", "armour", "augment", "term", "associate", "cargo", "hardware", "role", "software", "worlddata", "power" ],
     "templates": {
       "base": {
         "tl": 0,
@@ -365,6 +365,15 @@
           "bandwidth": 0
         },
         "installedOn": null
+      },
+      "power": {
+        "power": {
+          "check": "8",
+          "time": "1",
+          "range": "3",
+          "skill": "telepathy",
+          "cost": 0
+        }
       },
       "term": {
           "term": {
@@ -449,6 +458,9 @@
     },
     "associate": {
       "templates": [ "associate" ]
+    },
+    "power": {
+      "templates": [ "power" ]
     },
     "cargo": {
       "templates": [ "cargo"],

--- a/mgt2e/templates/actor/actor-traveller-sheet.html
+++ b/mgt2e/templates/actor/actor-traveller-sheet.html
@@ -129,6 +129,7 @@
                         {{#if system.characteristics.PSI.show}}
                           <a class="item" data-tab="powers">{{localize 'MGT2.TravellerSheet.Powers'}}</a>
                         {{/if}}
+                    {{/if}}
                     
                     <a class="item" data-tab="finance">{{localize 'MGT2.TravellerSheet.Finance'}}</a>
                     <a class="item" data-tab="biography">{{localize 'MGT2.TravellerSheet.Biography'}}</a>

--- a/mgt2e/templates/actor/actor-traveller-sheet.html
+++ b/mgt2e/templates/actor/actor-traveller-sheet.html
@@ -125,6 +125,9 @@
                 <nav class="sheet-tabs tabs" data-group="primary">
                     <a class="item" data-tab="skills">{{localize 'MGT2.TravellerSheet.Skills'}}</a>
                     <a class="item" data-tab="items">{{localize 'MGT2.TravellerSheet.Equipment'}}</a>
+                    {{#if system.characteristics.PSI.show}}
+                        <a class="item" data-tab="powers">{{localize 'MGT2.TravellerSheet.Powers'}}</a>
+                    {{/if}}
                     <a class="item" data-tab="finance">{{localize 'MGT2.TravellerSheet.Finance'}}</a>
                     <a class="item" data-tab="biography">{{localize 'MGT2.TravellerSheet.Biography'}}</a>
                     {{#if (isObserver .)}}
@@ -218,6 +221,15 @@
                         </section>
                     </div>
                     {{/if}}
+
+                    {{!-- {{#if (isObserver .)}} --}}
+                    <div class="tab powers" data-group="primary" data-tab="powers">
+                        <section>
+                            {{> "systems/mgt2e/templates/actor/parts/actor-powers.html"}}
+                        </section>
+                    </div>
+                    {{!-- {{/if}} --}}
+
 
                     {{#if (isObserver .)}}
                     {{!-- Owned Items Tab --}}

--- a/mgt2e/templates/actor/parts/actor-powers.html
+++ b/mgt2e/templates/actor/parts/actor-powers.html
@@ -1,0 +1,18 @@
+<h2>{{localize 'MGT2.TravellerSheet.Powers'}}</h2>
+
+<ol class="items-list actor-items grid grid-3col">
+    {{#each powers as |item id|}}
+        <li class="item item-{{item.type}} {{item.cssStyle}}" data-item-id="{{item._id}}">
+            <h4 title="{{nameQuantity item}}">{{nameQuantity item}}</h4>
+            <img title="{{nameQuantity item}}" src="{{item.img}}"/>
+            {{#if (isOwner ..)}}
+                <div class="item-controls">
+                    <a class="item-control rollable" data-roll-type="item" title="{{localize 'MGT2.EditItem'}}"><i class="fas fa-brain"></i></a>
+                    <a class="item-control item-edit" title="{{localize 'MGT2.EditItem'}}"><i class="fas fa-edit"></i></a>
+                    <a class="item-control item-delete" title="{{localize 'MGT2.DeleteItem'}}"><i class="fas fa-trash"></i></a>
+                </div>
+            {{/if}}
+        </li>
+    {{/each}}
+    <li></li>
+</ol>

--- a/mgt2e/templates/item/item-power-sheet.html
+++ b/mgt2e/templates/item/item-power-sheet.html
@@ -1,0 +1,66 @@
+<form class="{{cssClass}} item flexcol" autocomplete="off">
+    <section class="item-sheet">
+        <div class="sidebar">
+            <img class="item-img shadow" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+
+            {{#if system.status}}
+            <div class="item-status item-status-{{system.status}}">{{system.status}}</div>
+            {{/if}}
+
+        </div>
+
+        <div class="flex-group-left">
+            <h1 class="item-power charname shadow">
+                <input name="name" type="text" value="{{item.name}}" placeholder="Name" />
+                <span class="item-to-chat" data-item-id="{{item.uuid}}" title="{{localize 'MGT2.Item.ClickToChat'}}">
+                    <i class="fas fa-comment"></i>
+                </span>
+            </h1>
+            <div class="shadow">
+                <div class="resources grid grid-3col flex-group-left">
+                    <div class="resource ">
+                        <label for="system.power.check" class="resource-label">{{localize
+                            "MGT2.Psi.Check"}}</label><br />
+                        <select class="writable" name="system.power.check">
+                            {{selectOptions difficulty selected=system.power.check}}
+                        </select>
+                    </div>
+                    <div class="resource ">
+                        <label for="system.power.time" class="resource-label">{{localize
+                            "MGT2.Psi.Time"}}</label><br />
+                        <select class="writable" name="system.power.time">
+                            {{selectOptions timeFrame selected=system.power.time}}
+                        </select>
+                    </div>
+                    <div class="resource">
+                        <label for="system.power.skill" class="resource-label">{{localize
+                            "MGT2.Psi.Talent"}}</label><br />
+                        <select class="writable" name="system.power.skill">
+                            {{selectOptions psiSkills selected=system.power.skill}}
+                        </select>
+                    </div>
+                    <div class="resource grid-span-2">
+                        <label for="system.power.range" class="resource-label">{{localize
+                            "MGT2.Psi.Reach"}}</label><br />
+                        <select class="writable" name="system.power.range">
+                            {{selectOptions psionicRange selected=system.power.range}}
+                        </select>
+                    </div>
+                    <div class="resource">
+                        <label for="system.power.cost" class="resource-label">{{localize
+                            "MGT2.Psi.Cost"}}</label>
+                        <input class="writable" type="text" name="system.power.cost"
+                            value="{{system.power.cost}}" data-dtype="String" />
+                    </div>
+                </div>
+            </div>
+
+
+            <div class="item-description shadow">
+                {{editor enrichedDescription target="system.description"
+                button=true editable=editable}}
+            </div>
+        </div>
+    </section>
+
+</form>

--- a/mgt2e/templates/power-dialog.html
+++ b/mgt2e/templates/power-dialog.html
@@ -1,0 +1,44 @@
+<form class="flexcol skilldialog">
+    <div class="shadow">
+        <b>{{power.name}}</b><br/>
+        {{#if cha}}
+            <i>{{cha}} + {{skill}}{{#if speciality}} ({{speciality}}){{/if}} at {{score}}</i>
+        {{else}}
+            <i>{{skill}}{{#if speciality}} ({{speciality}}){{/if}} at {{score}}</i>
+        {{/if}}
+    </div>
+
+
+    <div class="shadow grid grid-3col">
+        <div class="mode-selection">
+            <label for="rollmode" class="skillDialogLabel">Roll Mode</label>
+            <select class="skillDialogRollMode" name="rollmode">
+                {{selectOptions MODE_SELECT selected=mode}}
+            </select>
+        </div>
+        <div class="boon-selection">
+            <label for="dicetype" class="skillDialogLabel">Roll Type</label>
+            <select class="skillDialogRollType" name="dicetype">
+                {{selectOptions ROLLTYPES selected="normal"}}
+            </select>
+        </div>
+
+        <div class="bonus-selection">
+            <label for="dm" class="skillDialogLabel">DM</label><br>
+            <input class="skillDialogDM" name="dm" type="text" data-dtype="Number" value="{{dm}}" />
+        </div>
+
+        <div class="range-selection grid-span-3">
+            <label for="range" class="skillDialogLabel">Range</label>
+            <select class="skillDialogRange" name="range">
+                {{selectOptions RANGES selected=system.power.range}}
+            </select>
+        </div>
+
+    </div>
+
+    <footer class="sheet-footer flexrow">
+        <button type="submit" name="submit" class="roll">Attack</button>
+    </footer>
+
+</form>

--- a/mgt2e/templates/power-dialog.html
+++ b/mgt2e/templates/power-dialog.html
@@ -38,7 +38,7 @@
     </div>
 
     <footer class="sheet-footer flexrow">
-        <button type="submit" name="submit" class="roll">Attack</button>
+        <button type="submit" name="submit" class="roll">Roll</button>
     </footer>
 
 </form>


### PR DESCRIPTION
Added a Power item type. These can be accessed on the character sheet by toggling the PSI characteristic, which enables a tab on the actor sheet. This also handles rolling, psi point consumption, damage for excessive psi-usage, increased range bands at the cost of psi-points, and disabling usage when psi is 0.

Missing Features:
- special chat message (currently uses the skill roll message)
- quick rolling
- allowing creatures to use psi powers
- sorting by talent

**Important Note:** The item uses skills with the 'psionic' trait in order to figure out what skills to put inside the &lt;Select&gt; element. But as far as i know, that can't be changed normally through the dialog to edit skills.

I'd like some feedback before going any further with this feature
Item Sheet
<img width="680" height="473" alt="image" src="https://github.com/user-attachments/assets/83b51cec-ea7d-42f6-a948-f38b88ced235" />

Appearance in the Actor Sheet
<img width="555" height="190" alt="image" src="https://github.com/user-attachments/assets/7dbda22c-214c-46fc-93d3-184705c4d980" />

Power Dialog
<img width="407" height="261" alt="image" src="https://github.com/user-attachments/assets/90002115-1aac-4568-b1f0-2ee2d286f7e9" />