### PR TITLE
V14 Active Effects fix

### DIFF
--- a/mgt2e/module/documents/actor.mjs
+++ b/mgt2e/module/documents/actor.mjs
@@ -25,6 +25,7 @@ export class MgT2Actor extends Actor {
 
     /** @override */
     prepareBaseData() {
+        super.prepareBaseData(); // needed to clear the ActiveEffect phases, so they can be applied.
         // Data modifications in this step occur before processing embedded
         // documents or derived data.
         if (this.system.hits && this.type !== "traveller") {

--- a/mgt2e/module/sheets/effect-sheet.mjs
+++ b/mgt2e/module/sheets/effect-sheet.mjs
@@ -146,7 +146,7 @@ export class MgT2EffectSheet extends foundry.applications.sheets.ActiveEffectCon
     async _prepareContext(options) {
         const context = await super._prepareContext(options);
         let augmentType = context.document.system?.augmentType;
-        if (augmentType === null) {
+        if ((augmentType === null) || (augmentType === undefined)) {
             // This is a pre-v13 augment, so need to try and fix it.
             console.log("Migrating effect to v13");
             if (context.document.flags.augmentType && typeof context.document.flags.augmentType === "string") {

--- a/mgt2e/system.json
+++ b/mgt2e/system.json
@@ -2,11 +2,11 @@
   "id": "mgt2e",
   "title": "Mongoose Traveller 2e",
   "description": "A system for Mongoose Traveller 2e. This includes rules specific to this version of Traveller.",
-  "version": "0.19.2.0",
+  "version": "0.19.2.1",
   "compatibility": {
     "minimum": 13,
     "verified": 13,
-    "maximum": 13
+    "maximum": 14
   },
   "authors": [
     {


### PR DESCRIPTION
I don't pretend to have tested this thoroughly, but there was an issue with Active Effects where they were applied once, and only once, and adding the call to super.prepareBaseData() fixed it, so it's at least a bit of progress. No console errors while clicking around rather randomly.

I also allowed it to work with v14, and ticked up the patch level for my testing, if you want I can roll those back.

Begins to address #109 