### PR TITLE
Fix non square item images

### DIFF
--- a/mgt2e/css/mgt2.css
+++ b/mgt2e/css/mgt2.css
@@ -1170,6 +1170,11 @@ img.item-img {
   border-radius: 10px;
   margin-bottom: 10px;
   padding: 0;
+  object-fit: scale-down;
+}
+
+li.item>img {
+  object-fit: scale-down;
 }
 
 div.item-side-panel {


### PR DESCRIPTION
This fixes the CSS that squashes item images if they are not square.