### PR TITLE
Fix Vehicle Sheet 2 crew roles and weapon attacks

### DIFF
--- a/mgt2e/module/helpers/dialogs/MgT2eAttackApp.mjs
+++ b/mgt2e/module/helpers/dialogs/MgT2eAttackApp.mjs
@@ -48,11 +48,17 @@ export class MgT2eAttackApp extends HandlebarsApplicationMixin(ApplicationV2) {
     }
 
     async _prepareContext(options) {
+        const characteristic = this.weaponItem.system.weapon.characteristic;
+        const skill = this.weaponItem.system.weapon.skill;
+        const characteristicDM = this.actor.system.characteristics?.[characteristic]?.dm || 0;
+        this.skillDM = this.actor.getSkillValue(skill, { cha: characteristic }) + characteristicDM;
+
         const context = {
             actor: this.actor,
             weaponItem: this.weaponItem,
-            rangeUnit: "m",
+            rangeUnit: this.weaponItem.system.weapon.scale === "vehicle" ? "km" : "m",
             skillText: this._getSkillText(),
+            skillDM: this.skillDM,
             buttons: [
                 { type: "submit", icon: "fa-solid fa-save", label: "Attack" }
             ]
@@ -91,14 +97,14 @@ export class MgT2eAttackApp extends HandlebarsApplicationMixin(ApplicationV2) {
     // Despite being static, formHandler has access to `this`
     static async formHandler(event, form, formData) {
 
-        console.log(formData.object.DM);
         let customDM = parseInt(formData.object.DM);
         if (isNaN(customDM)) {
             customDM = 0;
         }
+        const rangeDM = parseInt(formData.object.range);
 
         if (event.type === "submit") {
-            this.rollImpact(customDM);
+            this.rollImpact(customDM, rangeDM);
         }
 
         return null;
@@ -110,7 +116,11 @@ export class MgT2eAttackApp extends HandlebarsApplicationMixin(ApplicationV2) {
         // Do nothing. We should already have a target by this point.
     }
 
-    rollImpact(customDM) {
+    rollImpact(customDM, rangeDM) {
+        this.attackOptions.skillDM = this.skillDM;
+        this.attackOptions.dm = customDM;
+        this.attackOptions.rangeDM = rangeDM;
+        this.attackOptions.showBreakdown = true;
 
         rollAttack(this.actor, this.weaponItem, this.attackOptions);
         this.close();

--- a/mgt2e/module/helpers/dice-rolls.mjs
+++ b/mgt2e/module/helpers/dice-rolls.mjs
@@ -192,7 +192,7 @@ export async function rollAttack(actor, weapon, attackOptions) {
     }
 
     if (attackOptions.skillDM !== 0) {
-        dice += ` + ${attackOptions.skillDM}`;
+        dice += ` + ${attackOptions.skillDM}[Skill]`;
     }
     if (system) {
         if (system.modifiers && system.modifiers.encumbrance.dm !== 0) {
@@ -370,9 +370,9 @@ export async function rollAttack(actor, weapon, attackOptions) {
 
     if (attackOptions.dm && parseInt(attackOptions.dm) !== 0) {
         if (attackOptions.dm > 0) {
-            dice += ` + ${parseInt(attackOptions.dm)}`;
+            dice += ` + ${parseInt(attackOptions.dm)}[DM]`;
         } else {
-            dice += ` - ${Math.abs(parseInt(attackOptions.dm))}`;
+            dice += ` - ${Math.abs(parseInt(attackOptions.dm))}[DM]`;
         }
     }
     if (attackOptions.rangeDM) {
@@ -422,13 +422,14 @@ export async function rollAttack(actor, weapon, attackOptions) {
         let reducedTotal = (await new Roll(redDice, actor?actor.getRollData():null).evaluate()).total;
         let minimumTotal = (await new Roll(minDice, actor?actor.getRollData():null).evaluate()).total;
 
-        let effect = 0, attackTotal = 0;
+        let effect = 0, attackTotal = 0, attackDiceTotal = 0;
         if (actor) {
             const attackRoll = await new Roll(dice, actor ? actor.getRollData() : null).evaluate();
             if (!roll) {
                 roll = attackRoll;
             }
             attackTotal = attackRoll.total;
+            attackDiceTotal = attackRoll.dice.reduce((total, die) => total + die.total, 0);
             effect = attackTotal - 8;
         }
 
@@ -557,6 +558,11 @@ export async function rollAttack(actor, weapon, attackOptions) {
             if (actor) {
                 content += `<b>${game.i18n.localize("MGT2.AttackRoll")}:</b> ${dice}<br/>`
                 content += `<span class="skill-roll inline-roll inline-result"><i class="fas fa-dice"> </i> ${attackTotal}</span> <span class="${effectClass}">${effectText}</span><br/>`;
+                if (attackOptions.showBreakdown) {
+                    const modifierTotal = attackTotal - attackDiceTotal;
+                    const modifierSign = modifierTotal >= 0 ? "+" : "-";
+                    content += `Dice ${attackDiceTotal} ${modifierSign} Modifiers ${Math.abs(modifierTotal)} = Total ${attackTotal}<br/>`;
+                }
             } else {
                 content += "<br/>";
             }

--- a/mgt2e/module/mgt2.mjs
+++ b/mgt2e/module/mgt2.mjs
@@ -2942,6 +2942,7 @@ Handlebars.registerHelper("weaponMountBlock", function(mount) {
         if (system.weapon.traits) {
             html += `<br/><span class="weapon-traits">${printWeaponTraits(system.weapon.traits)}</span>`;
         }
+        html += `<br/><span class="action" data-action="attack" data-item-id="${weaponItem.id}" data-mount-id="${mountItem.id}">${game.i18n.localize("MGT2.TravellerSheet.Attack")}</span>`;
         html += `<br/>`;
         if (system.weapon.scale === "spacecraft") {
             html += `${game.i18n.localize("MGT2.Spacecraft.Range." + system.weapon.spaceRange)}`;

--- a/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
+++ b/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
@@ -1,3 +1,4 @@
+import {MgT2AttackDialog} from "../../helpers/attack-dialog.mjs";
 import {MgT2CrewMemberDialog} from "../../helpers/crew-member-dialog.mjs";
 import {MgT2eAttackApp} from "../../helpers/dialogs/MgT2eAttackApp.mjs";
 
@@ -76,24 +77,38 @@ export class MgT2eActorV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         const weaponItem = this.document.items.get(itemId);
         const mountItem = this.document.items.get(mountId);
 
+        if (!mountId) {
+            if (weaponItem) {
+                new MgT2AttackDialog(this.actor, weaponItem).render(true);
+            } else {
+                ui.notifications.warn("Cannot find the weapon.");
+            }
+            return;
+        }
+
         if (!weaponItem || !mountItem) {
             ui.notifications.warn("Cannot find the vehicle weapon or its mount.");
             return;
         }
 
         let gunnerActor;
+        let fallbackGunnerActor;
         for (const [crewId, assignments] of Object.entries(this.document.system.crewed?.crew || {})) {
             for (const roleId of Object.keys(assignments)) {
                 const roleItem = this.document.items.get(roleId);
                 const weaponActions = Object.values(roleItem?.system.role.actions || {})
                     .filter(action => action.action === "weapon");
-                if (weaponActions.some(action => !action.weapon || action.weapon === mountId)) {
+                if (weaponActions.some(action => action.weapon === mountId)) {
                     gunnerActor = game.actors.get(crewId);
                     break;
+                }
+                if (!fallbackGunnerActor && weaponActions.some(action => !action.weapon)) {
+                    fallbackGunnerActor = game.actors.get(crewId);
                 }
             }
             if (gunnerActor) break;
         }
+        gunnerActor ||= fallbackGunnerActor;
 
         if (!gunnerActor) {
             ui.notifications.warn("Assign a crew member to a Gunner role before attacking.");

--- a/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
+++ b/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
@@ -1,4 +1,3 @@
-import {MgT2AttackDialog} from "../../helpers/attack-dialog.mjs";
 import {MgT2CrewMemberDialog} from "../../helpers/crew-member-dialog.mjs";
 import {MgT2eAttackApp} from "../../helpers/dialogs/MgT2eAttackApp.mjs";
 
@@ -73,13 +72,39 @@ export class MgT2eActorV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
 
     static async #onAttack(event, target) {
         const itemId = event.target.dataset["itemId"];
-        const item = this.document.items.get(itemId);
+        const mountId = event.target.dataset["mountId"];
+        const weaponItem = this.document.items.get(itemId);
+        const mountItem = this.document.items.get(mountId);
 
-        if (item) {
-            new MgT2AttackDialog(this.actor, item).render(true);
-        } else {
-            console.log("No item found");
+        if (!weaponItem || !mountItem) {
+            ui.notifications.warn("Cannot find the vehicle weapon or its mount.");
+            return;
         }
+
+        let gunnerActor;
+        for (const [crewId, assignments] of Object.entries(this.document.system.crewed?.crew || {})) {
+            for (const roleId of Object.keys(assignments)) {
+                const roleItem = this.document.items.get(roleId);
+                const weaponActions = Object.values(roleItem?.system.role.actions || {})
+                    .filter(action => action.action === "weapon");
+                if (weaponActions.some(action => !action.weapon || action.weapon === mountId)) {
+                    gunnerActor = game.actors.get(crewId);
+                    break;
+                }
+            }
+            if (gunnerActor) break;
+        }
+
+        if (!gunnerActor) {
+            ui.notifications.warn("Assign a crew member to a Gunner role before attacking.");
+            return;
+        }
+
+        new MgT2eAttackApp(gunnerActor, weaponItem, {
+            vehicle: this.document,
+            mount: mountItem,
+            dm: 0
+        }).render(true);
     }
 
     static async #onReload(event, target) {

--- a/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
+++ b/mgt2e/module/sheets/v2/MgT2eActorV2.mjs
@@ -220,6 +220,89 @@ export class MgT2eActorV2 extends HandlebarsApplicationMixin(ActorSheetV2) {
         }
     }
 
+    async _createCrewRole(roleType) {
+        const system = {
+            description: "",
+            role: {
+                actions: {},
+                department: false,
+                colour: null,
+                dei: 0
+            }
+        };
+        let itemName;
+        let img;
+        let timestamp = Date.now();
+        const addAction = (action) => {
+            system.role.actions[(timestamp++).toString(36)] = action;
+        };
+
+        switch (roleType) {
+            case "gunner":
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Gunner");
+                img = "systems/mgt2e/icons/items/roles/gunner.svg";
+                addAction({ title: itemName, action: "weapon", dm: 0, weapon: null });
+                break;
+            case "pilot": {
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Pilot");
+                img = "systems/mgt2e/icons/items/roles/pilot.svg";
+                let skill = this.document.system.vehicle?.skill || "pilot.spacecraft";
+                const dtons = this.document.system.spacecraft?.dtons;
+                if (dtons < 100) {
+                    skill = "pilot.smallCraft";
+                } else if (dtons > 5000) {
+                    skill = "pilot.capitalShips";
+                }
+                addAction({
+                    title: game.i18n.localize("MGT2.Role.BuiltIn.Action.Pilot"),
+                    action: "skill", cha: "DEX", skill, target: 8, dm: 0
+                });
+                break;
+            }
+            case "engineer":
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Engineer");
+                img = "systems/mgt2e/icons/items/roles/engineer.svg";
+                addAction({
+                    title: "Repair", action: "skill", cha: "INT",
+                    skill: "mechanic", target: 8, dm: 0
+                });
+                break;
+            case "sensors":
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Sensors");
+                img = "systems/mgt2e/icons/items/roles/sensors.svg";
+                addAction({
+                    title: itemName, action: "skill", cha: "INT",
+                    skill: "electronics.sensors", target: 8, dm: 0
+                });
+                break;
+            case "navigator":
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Navigator");
+                img = "systems/mgt2e/icons/items/roles/navigator.svg";
+                addAction({
+                    title: itemName, action: "skill", cha: "EDU",
+                    skill: "navigation", target: 8, dm: 0
+                });
+                break;
+            case "broker":
+                itemName = game.i18n.localize("MGT2.Role.BuiltIn.Name.Broker");
+                img = "systems/mgt2e/icons/items/roles/broker.svg";
+                addAction({
+                    title: itemName, action: "skill", cha: "INT",
+                    skill: "broker", target: 8, dm: 0
+                });
+                break;
+            default:
+                return;
+        }
+
+        return this.document.createEmbeddedDocuments("Item", [{
+            name: itemName,
+            img,
+            type: "role",
+            system
+        }]);
+    }
+
     async _prepareItems(context) {
         context.ITEMS = this.document.items;
         context.ITEMS_WEAPONS = [];

--- a/mgt2e/templates/dialogs/attack-dialog.html
+++ b/mgt2e/templates/dialogs/attack-dialog.html
@@ -20,9 +20,11 @@
 
         <div class="resource flex-group-center">
             <label class="field-label">{{localize 'MGT2.DM'}}</label>
-            <span></span>
+            <input type="number" name="DM" value="0"/>
         </div>
     </div>
+
+    <div>Skill DM: {{skillDM}}</div>
 
     {{#if weaponItem.system.weapon.traits}}
         <div>


### PR DESCRIPTION
## Summary

- allow Vehicle Sheet 2 to create and assign crew roles
- add an Attack action to mounted vehicle weapons
- resolve the assigned Gunner, weapon, and mount for attacks
- apply weapon skill, characteristic, range, and custom DMs
- display vehicle ranges in kilometres and show dice, modifier, and final totals
- preserve the existing unmounted Robot Sheet 2 attack path

## Why

Vehicle Sheet 2 rendered mounted weapons but did not expose an attack action. Its crew-role dialog also called a role-creation method that the Sheet 2 base class did not implement. The new attack application displayed skill and range controls but did not pass their modifiers to the roller.

## Validation

Tested with Foundry VTT 14 Build 365 and MGT2E 0.22.2 in a disposable world:

- created and assigned a Gunner role and confirmed it persisted after reopening the sheet
- attacked with a Fusion Gun in a turret using the assigned Gunner
- resolved Heavy Weapons (Vehicle) 2 and DEX DM 0
- confirmed Medium range: dice 11 + modifiers 2 = total 13
- confirmed Short range: dice 11 + modifiers 3 = total 14
- confirmed hit, effect, damage, AP, Radiation, Blast, and Destructive output
- verified the unmounted Robot attack path remains available in the shared Sheet 2 handler
- `node --check` passed for all changed JavaScript modules
- `git diff --check` passed

No compendium or world data is included.

Related to #127.
